### PR TITLE
Make use of the `move` parameter to the *scan* resource

### DIFF
--- a/manifests/scan.pp
+++ b/manifests/scan.pp
@@ -77,7 +77,7 @@ define clamav::scan (
   $flags = '',
   $include = [ ],
   $include_dir = [ ],
-  $move = false,
+  $move = '',
   $quiet = true,
   $recursive = false,
   $scan = [ ],

--- a/spec/defines/clamav_scan_spec.rb
+++ b/spec/defines/clamav_scan_spec.rb
@@ -21,6 +21,13 @@ describe 'clamav::scan' do
     end
   end
 
+  context 'with move directory' do
+    let(:params) { {'move' => '/var/lib/clamav/quarantine'} }
+    it { should contain_file('/etc/clamav/scans/virus-scan').with_content(
+      /--move=\/var\/lib\/clamav\/quarantine/
+    )}
+  end
+
   context 'scheduled scan' do
     #
     # Test for disabled scans

--- a/templates/scan.sh.erb
+++ b/templates/scan.sh.erb
@@ -9,12 +9,13 @@ INC="<% @include.each do |inc| %> --include=<%= inc %><% end -%>"
 INC_DIR="<% @include_dir.each do |inc| %> --include-dir=<%= inc %><% end -%>"
 EXC="<% @exclude.each do |exc| %> --exclude=<%= exc %><% end -%>"
 EXC_DIR="<% @exclude_dir.each do |exc| %> --exclude-dir=<%= exc %><% end -%>"
+MOVE="<% if @move %> --move=<%= @move -%><% end -%>"
 SCAN="<%= @scan.join(' ') %>"
 RECURSIVE="<% if @recursive %>-r<% end -%>"
 QUIET="<% if @quiet %>--quiet<% end -%>"
 LOG="<%= @scanlog %>"
 
-$BIN $INC $INC_DIR $EXC $EXC_DIR $QUIET $RECURSIVE -l $LOG $SCAN
+$BIN $INC $INC_DIR $EXC $EXC_DIR $MOVE $QUIET $RECURSIVE -l $LOG $SCAN
 AVSTATUS=$?
 
 # Detect the result of our scan


### PR DESCRIPTION
I noticed the `move` parameter was already in place, but wasn't being used.  This makes it work.
