### PR TITLE
Fix dependency on /etc/clamav/scans for the Scan resource

### DIFF
--- a/manifests/scan.pp
+++ b/manifests/scan.pp
@@ -86,7 +86,7 @@ define clamav::scan (
 ) {
   if $move != '' { validate_absolute_path($move) }
 
-  include clamav::params
+  include clamav
   $scancmd = "/etc/clamav/scans/${title}"
 
   file { $scancmd:
@@ -94,6 +94,7 @@ define clamav::scan (
     owner   => $clamav::params::user,
     mode    => '0500',
     content => template('clamav/scan.sh.erb'),
+    require => Class['Clamav'],
   }
 
   # setup our scheduled job to run this scan

--- a/spec/defines/clamav_scan_spec.rb
+++ b/spec/defines/clamav_scan_spec.rb
@@ -3,6 +3,36 @@ require 'spec_helper'
 describe 'clamav::scan' do
   let(:title) { 'virus-scan' }
 
+  context 'default parameters' do
+    let(:params) { { } }
+    it { should compile }
+    it { should contain_file('/etc/clamav').with({
+      :ensure => 'directory',
+      :owner  => 'clam',
+    })}
+    it { should contain_file('/etc/clamav/scans').with({
+      :ensure => 'directory',
+      :owner  => 'clam',
+    })}
+    it { should contain_file('/etc/clamav/scans/virus-scan').with({
+      :ensure  => 'present',
+      :owner   => 'clam',
+      :mode    => '0500',
+      :require => 'Class[Clamav]',
+      :content => /\/var\/log\/clamav\/scan_virus-scan/,
+    })}
+    it { should contain_cron('clamav-scan-virus-scan').with({
+      :ensure   => 'present',
+      :command  => '/etc/clamav/scans/virus-scan',
+      :hour     => /[0-9]|[1-5][0-9]/,
+      :minute   => /[0-9]|[1-5][0-9]/,
+      :weekday  => nil,
+      :month    => nil,
+      :monthday => nil,
+      :require  => 'File[/etc/clamav/scans/virus-scan]',
+    })}
+  end
+
   context 'verify action items' do
     let(:params) { {
       'action_virus' => '/usr/local/sbin/send-virus-alert',


### PR DESCRIPTION
To ensure /etc/clamav/scans exists prior to creating a file, this makes
clamav::scan include the base class and requires it for the scan file.
I've also added a few tests for the default parameters.
