### PR TITLE
whitelists & bin path

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,4 +4,4 @@ fixtures:
   repositories:
     "stdlib":
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-      ref: "2.6.0"
+      ref: "4.2.1"

--- a/README.markdown
+++ b/README.markdown
@@ -15,6 +15,22 @@ not run on a schedule.
        enable      => false,
      }
 
+Add signature and file whitelist entries in `/var/lib/clamav/local.ign2`,
+`/var/lib/clamav/local.sfp`, and `/var/lib/clamav/local.fp`:
+
+    class { 'clamav':
+      whitelist_sig => [
+	    'ClamAV-Test-Signature',
+		'Eicar-Test-Signature:bc356bae4c42f19a3de16e333ba3569c',
+      ],
+	  whitelist_sha => [
+        'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      ],
+      whitelist_md5 => [ 'd41d8cd98f00b204e9800998ecf8427e' ]
+	}
+
+
 License
 -------
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,13 +2,57 @@
 #
 # Install clamav
 #
-class clamav {
+class clamav (
+  $whitelist_sig = [],
+  $whitelist_sha = [],
+  $whitelist_md5 = [],
+) {
   include clamav::package
   include clamav::params
 
+  validate_array($whitelist_sig)
+  validate_array($whitelist_sha)
+  validate_array($whitelist_md5)
+
+  $whitelist_sig_count = count($whitelist_sig)
+  $whitelist_sha_count = count($whitelist_sha)
+  $whitelist_md5_count = count($whitelist_md5)
+
+  $whitelist_sig_ensure = $whitelist_sig_count ? {
+    0       => absent,
+    default => file,
+  }
+  $whitelist_sha_ensure = $whitelist_sha_count ? {
+    0       => absent,
+    default => file,
+  }
+  $whitelist_md5_ensure = $whitelist_md5_count ? {
+    0       => absent,
+    default => file,
+  }
+
+  File {
+    owner   => $clamav::params::user,
+    group   => $clamav::params::user,
+    require => Class['clamav::package'],
+  }
+
   file { [ '/etc/clamav', '/etc/clamav/scans' ]:
     ensure  => directory,
-    owner   => $clamav::params::user,
-    require => Class['clamav::package']
+  }
+
+  file { '/var/lib/clamav/local.ign2':
+    ensure  => $whitelist_sig_ensure,
+    content => template('clamav/whitelist.ign2.erb')
+  }
+
+  file { '/var/lib/clamav/local.sfp':
+    ensure  => $whitelist_sha_ensure,
+    content => template('clamav/whitelist.sfp.erb')
+  }
+
+  file { '/var/lib/clamav/local.fp':
+    ensure  => $whitelist_md5_ensure,
+    content => template('clamav/whitelist.fp.erb')
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,9 +2,11 @@ class clamav::params {
   case $::osfamily {
     'Debian': {
       $user = 'clamav'
+      $clamscan_bin = '/usr/bin/clamscan'
     }
     default: {
       $user = 'clam'
+      $clamscan_bin = '/usr/bin/clamscan'
     }
   }
 

--- a/manifests/scan.pp
+++ b/manifests/scan.pp
@@ -83,11 +83,20 @@ define clamav::scan (
   $scan = [ ],
   $scanlog = "/var/log/clamav/scan_${title}",
   $weekday = 'UNSET',
+  $clamscan_bin = 'UNSET',
 ) {
   if $move != '' { validate_absolute_path($move) }
 
   include clamav
   $scancmd = "/etc/clamav/scans/${title}"
+
+  case $clamscan_bin {
+    'UNSET': { $clamscan = $::clamav::params::clamscan_bin }
+    default: {
+      validate_absolute_path($clamscan_bin)
+      $clamscan = $clamscan_bin
+    }
+  }
 
   file { $scancmd:
     ensure  => present,

--- a/spec/defines/clamav_scan_spec.rb
+++ b/spec/defines/clamav_scan_spec.rb
@@ -19,7 +19,7 @@ describe 'clamav::scan' do
       :owner   => 'clam',
       :mode    => '0500',
       :require => 'Class[Clamav]',
-      :content => /\/var\/log\/clamav\/scan_virus-scan/,
+      :content => /^BIN='\/usr\/bin\/clamscan'$/,
     })}
     it { should contain_cron('clamav-scan-virus-scan').with({
       :ensure   => 'present',
@@ -63,6 +63,25 @@ describe 'clamav::scan' do
     it { should contain_file('/etc/clamav/scans/virus-scan').with_content(
       /--move=\/var\/lib\/clamav\/quarantine/
     )}
+  end
+
+  context 'with an alternative binary defined' do
+    let :params do { :clamscan_bin => '/usr/local/bin/clamscan' } end
+    it { should contain_file('/etc/clamav/scans/virus-scan').with_content(
+      /^BIN='\/usr\/local\/bin\/clamscan'$/
+    )}
+  end
+
+  context 'with an invalid binary defined' do
+    let :params do { :clamscan_bin => '$(which clamscan)' } end
+    it do
+      expect {
+        should compile
+      }.to raise_error(
+        Puppet::Error,
+        /"\$\(which clamscan\)" is not an absolute path./
+      )
+    end
   end
 
   context 'scheduled scan' do

--- a/templates/scan.sh.erb
+++ b/templates/scan.sh.erb
@@ -4,7 +4,7 @@
 # ClamAV Scan
 # Scan Name: <%= @title %>
 ###############################################################################
-BIN=$(which clamscan)
+BIN='<%= @clamscan %>'
 INC="<% @include.each do |inc| %> --include=<%= inc %><% end -%>"
 INC_DIR="<% @include_dir.each do |inc| %> --include-dir=<%= inc %><% end -%>"
 EXC="<% @exclude.each do |exc| %> --exclude=<%= exc %><% end -%>"

--- a/templates/whitelist.fp.erb
+++ b/templates/whitelist.fp.erb
@@ -1,0 +1,3 @@
+<% Array(whitelist_md5).flatten.compact.each do |entry| -%>
+<%= entry %>
+<% end -%>

--- a/templates/whitelist.ign2.erb
+++ b/templates/whitelist.ign2.erb
@@ -1,0 +1,3 @@
+<% Array(whitelist_sig).flatten.compact.each do |entry| -%>
+<%= entry %>
+<% end -%>

--- a/templates/whitelist.sfp.erb
+++ b/templates/whitelist.sfp.erb
@@ -1,0 +1,3 @@
+<% Array(whitelist_sha).flatten.compact.each do |entry| -%>
+<%= entry %>
+<% end -%>


### PR DESCRIPTION
The first commit in this PR adds basic support for whitelists as described in the ClamAV developer manual, [Creating signatures for ClamAV](https://github.com/vrtadmin/clamav-devel/blob/master/docs/signatures.pdf?raw=true) (pdf).  It creates three file resources, `/var/lib/clamav/local.ign2`, `/var/lib/clamav/local.sfp` and `/var/lib/clamav/local.fp.  Each takes an array via a parameter to the init class.

The second commit changes the default binary from the one found with `$(which clamscan)` to a  fully-qualified path with a parameter to change it.  This might break some installs.  Let me know if you want it in a separate PR.

Also included in both commits are several spec tests.  Mostly they cover their own features, but a lot of the structure should help more generally.