### PR TITLE
Fix typo for partition_intersection variable in erb template.

### DIFF
--- a/templates/clamd.conf.erb
+++ b/templates/clamd.conf.erb
@@ -356,7 +356,7 @@ PhishingAlwaysBlockCloak <%= @phishing_always_block_cloak %>
 
 # Detect partition intersections in raw disk images using heuristics.
 # Default: no
-PartitionIntersection <%= partition_intersection %>
+PartitionIntersection <%= @partition_intersection %>
 
 # Allow heuristic match to take precedence.
 # When enabled, if a heuristic scan (such as phishingScan) detects


### PR DESCRIPTION
Fixes failure to parse template under Puppet 4.x because of undefined local variable error message.

```
Detail: undefined local variable or method `partition_intersection' for #<Puppet::Parser::TemplateWrapper:0x6a36d117>
```